### PR TITLE
허브 메뉴 상단 가독성 개선 (#4)

### DIFF
--- a/_sass/base_styles.scss
+++ b/_sass/base_styles.scss
@@ -133,7 +133,7 @@ a, .btn {
   }
 
   &.hub-background {
-    background-image: url($baseurl + "/assets/images/hub-background.jpg");
+    background-color: $light_grey;
   }
 
    &.ecosystem-background {

--- a/_sass/hub.scss
+++ b/_sass/hub.scss
@@ -1,7 +1,7 @@
 .hub .jumbotron {
-  height: 240px;
+  height: 375px;
   @include desktop {
-    height: 340px;
+    height: 420px;
   }
 
   h1 {
@@ -15,8 +15,8 @@
   }
 
   p.lead, p.hub-release-message {
-    margin-bottom: rem(10px);
-    padding-top: rem(5px);
+    margin-bottom: rem(15px);
+    padding-top: rem(35px);
     color: $dark_grey;
 
     @include desktop {

--- a/hub/hub.html
+++ b/hub/hub.html
@@ -9,7 +9,8 @@ body-class: hub
 <div class="jumbotron jumbotron-fluid">
   <div class="container">
     <h1>
-      <span id="hub-header">파이토치</span> <span id="hub-sub-header">허브</span>
+      <span id="hub-header">파이토치</span> <br />
+      <span id="hub-sub-header">허브</span>
     </h1>
 
     <p class="lead">


### PR DESCRIPTION
## 🕋 문제 상황

* 개요: 허브 메뉴 상단의 배경색과 글자색이 비슷하여 가독성이 떨어지는 것을 개선하였습니다.
* 내용: 배경 이미지를 삭제하는 식으로 PyTorch 공식 홈페이지의 스타일을 적용하였습니다.

* 관련 이슈: fix #4 

## 스크린샷

### 공식 스크린샷

**목록 화면**
![image](https://user-images.githubusercontent.com/9343724/166146150-59cb6073-7a95-4316-afc8-013430b7fc99.png)

**모델 화면**
![image](https://user-images.githubusercontent.com/9343724/166146162-2b2bef66-aaa6-4583-bdf8-79469cf1ed4d.png)


### PR 스크린샷

**목록 화면**
![image](https://user-images.githubusercontent.com/9343724/166146215-31c4a5c0-6869-4a11-92e1-e5031f5f9f62.png)

**모델 화면**
![image](https://user-images.githubusercontent.com/9343724/166146226-4a86326f-edbb-4d18-ba06-7485835c8a5f.png)

