### PR TITLE
fix: accelerating-large-language-models 글의 org_link 정정

### DIFF
--- a/_posts/2023-04-19-accelerating-large-language-models.md
+++ b/_posts/2023-04-19-accelerating-large-language-models.md
@@ -4,7 +4,7 @@ title: 가속화된 트랜스포머로 대규모 언어 모델 가속화하기
 org_title: Accelerating Large Language Models with Accelerated Transformers
 author: Lucas Pasqualin, Driss Guessous, Christian Puhrsch, Bertrand Maher, Michael Gschwind
 category: ["pytorch.org", "translation"]
-org_link: https://pytorch.org/blog/announcing-docathon/
+org_link: https://pytorch.org/blog/accelerating-large-language-models/
 discuss_id: 1417
 ---
 


### PR DESCRIPTION
## 수정 내용

`_posts/2023-04-19-accelerating-large-language-models.md` 의 `org_link` 가 인접 글(`2023-05-03-announcing-docathon.md`)의 링크로 잘못 복사되어 있어 정정합니다.

- 변경 전: `https://pytorch.org/blog/announcing-docathon/`
- 변경 후: `https://pytorch.org/blog/accelerating-large-language-models/`

본문 번역 내용(nanoGPT·SDPA·flash attention 기반 LLM 가속)은 원문과 일치하며, 잘못된 것은 `org_link` 한 줄뿐입니다. 전체 번역글 `org_link` 일괄 점검 중 발견했습니다.