### PR TITLE
커뮤니티 최신 글 위젯 SEO 개선

### DIFF
--- a/assets/community-widget.js
+++ b/assets/community-widget.js
@@ -13,13 +13,7 @@
   var TOPIC_COUNT = 12;
   var FETCH_TIMEOUT_MS = 8000;
   var CONTAINER_ID = 'community-topics-list';
-  var DEFAULT_THUMBNAIL = 'data:image/svg+xml,' + encodeURIComponent(
-    '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">' +
-      '<rect width="120" height="120" fill="#f3f4f7"/>' +
-      '<text x="60" y="52" text-anchor="middle" font-family="sans-serif" font-size="18" font-weight="bold" fill="#ee4c2c" opacity="0.4">PyTorch</text>' +
-      '<text x="60" y="76" text-anchor="middle" font-family="sans-serif" font-size="18" font-weight="bold" fill="#ee4c2c" opacity="0.4">Korea</text>' +
-    '</svg>'
-  );
+  var DEFAULT_THUMBNAIL = '/assets/images/community-topic-placeholder.svg';
 
   function escapeHtml(str) {
     var div = document.createElement('div');
@@ -90,7 +84,7 @@
 
     return (
       '<div class="col-sm-6 col-lg-4 col-xl-3 mb-2">' +
-        '<a href="' + url + '" target="_blank" rel="noopener" class="community-topic-item">' +
+        '<a href="' + url + '" target="_blank" rel="noopener ugc" class="community-topic-item">' +
           '<div class="topic-thumbnail">' +
             '<img src="' + imgSrc + '" alt="" loading="lazy" onerror="this.onerror=null;this.src=\'' + DEFAULT_THUMBNAIL + '\';">' +
           '</div>' +

--- a/assets/images/community-topic-placeholder.svg
+++ b/assets/images/community-topic-placeholder.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120" role="img" aria-label="PyTorch Korea">
+  <rect width="120" height="120" fill="#f3f4f7"/>
+  <text x="60" y="52" text-anchor="middle" font-family="sans-serif" font-size="18" font-weight="bold" fill="#ee4c2c" opacity="0.4">PyTorch</text>
+  <text x="60" y="76" text-anchor="middle" font-family="sans-serif" font-size="18" font-weight="bold" fill="#ee4c2c" opacity="0.4">Korea</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -65,11 +65,11 @@ display-news-banner: true
     <div class="container">
       <div class="row align-items-center mb-3">
         <div class="col">
-          <h2>커뮤니티 최신 글</h2>
+          <h2>PyTorchKR 커뮤니티 최신 글</h2>
           <p>AI/ML 분야의 최신 정보를 얻고, 다른 개발자들과 경험과 지식을 나누며 함께 성장하세요!</p>
         </div>
         <div class="col-auto">
-          <a href="https://discuss.pytorch.kr/" target="_blank" class="btn btn-lg community-btn" data-cta="community">
+          <a href="https://discuss.pytorch.kr/" target="_blank" rel="noopener" class="btn btn-lg community-btn" data-cta="community">
             커뮤니티 참여하기
           </a>
         </div>


### PR DESCRIPTION
## 변경 사항
- 자동 노출되는 Discuss 토픽 링크에 `rel="ugc"`를 추가했습니다.
- 홈페이지 섹션 제목을 `PyTorchKR 커뮤니티 최신 글`로 구체화했습니다.
- 반복되는 data URI placeholder를 정적 SVG 자산으로 교체했습니다.
- 커뮤니티 참여 CTA는 일반 링크로 유지하고 `noopener`만 적용했습니다.

## 목적
자동으로 노출되는 사용자 생성 콘텐츠 링크를 명확히 분류하고, 홈페이지의 PyTorchKR 주제성을 강화하며, Google 렌더링 HTML에 반복 삽입되던 긴 data URI를 줄입니다.

## 검증
- `node --check assets/community-widget.js`
- `xmllint --noout assets/images/community-topic-placeholder.svg`
- 프로덕션 Jekyll 빌드 성공
- `jekyll doctor` 통과
- 생성 HTML에서 제목·CTA·정적 자산 경로 확인
- `git diff --check` 통과